### PR TITLE
Prevent 100% CPU spin while waiting on blocks.

### DIFF
--- a/node/silkworm/stagedsync/stage_direct_bodies.cpp
+++ b/node/silkworm/stagedsync/stage_direct_bodies.cpp
@@ -48,7 +48,7 @@ Stage::Result DirectBodiesStage::forward(db::RWTxn& txn) {
 
     try {
         std::shared_ptr<silkworm::Block> b;
-        if( ! block_queue_.try_pop(b) ) {
+        if (!block_queue_.timed_wait_and_pop(b, 1000ms)) {
             return Stage::Result::kSuccess;
         }
 


### PR DESCRIPTION
Currently silkworm spins at 100% CPU when waiting on blocks. 
Silkworm when run with `BlockExchange` for receiving blocks uses a `timed_wait_and_pop` on incoming messages. Since we do not use the `BlockExchange`, do something similar in our `DirectBodiesStage`.