### PR TITLE
Fix shutdown during start of worker

### DIFF
--- a/node/silkworm/concurrency/worker.cpp
+++ b/node/silkworm/concurrency/worker.cpp
@@ -52,7 +52,7 @@ void Worker::start(bool wait) {
 
     while (wait) {
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
-        if (auto state{get_state()}; state == State::kStarted || state == State::kKickWaiting) {
+        if (auto state{get_state()}; state != State::kStarting) {
             break;
         }
     }


### PR DESCRIPTION
If ctrl-c during start of `Worker` the `start` method can be stuck in `while` loop waiting for state to change to `kStarted` which will never happen. Change logic to break on any state that is not `kStarting`.

Resolves https://github.com/eosnetworkfoundation/TrustEVM/issues/215