### PR TITLE
Remove c++20ish so code can be included in contract code

### DIFF
--- a/core/silkworm/trie/node.hpp
+++ b/core/silkworm/trie/node.hpp
@@ -50,8 +50,6 @@ class Node {
 
     void set_root_hash(const std::optional<evmc::bytes32>& root_hash);
 
-    friend bool operator==(const Node&, const Node&) = default;
-
     //! \see Erigon's MarshalTrieNodeTyped
     [[nodiscard]] Bytes encode_for_storage() const;
 


### PR DESCRIPTION
The operator== default is C++20 feature. Not used, so just remove it.