### PR TITLE
Properly flush topics/addresses bitmap to db during stage log index.

### DIFF
--- a/node/silkworm/stagedsync/stage_log_index.cpp
+++ b/node/silkworm/stagedsync/stage_log_index.cpp
@@ -376,6 +376,18 @@ void LogIndex::collect_bitmaps_from_logs(db::RWTxn& txn,
 
         source_data = source.to_next(/*throw_notfound=*/false);
     }
+
+    if (topics_bitmaps_size > 0) {
+        db::bitmap::IndexLoader::flush_bitmaps_to_etl(topics_bitmaps,
+                                                      topics_collector_.get(),
+                                                      topics_flush_count);
+    }
+    
+    if (addresses_bitmaps_size > 0) {
+        db::bitmap::IndexLoader::flush_bitmaps_to_etl(addresses_bitmaps,
+                                                      addresses_collector_.get(),
+                                                      addresses_flush_count);
+    }
 }
 
 void LogIndex::collect_unique_keys_from_logs(db::RWTxn& txn,


### PR DESCRIPTION
Part of the fixing for https://github.com/eosnetworkfoundation/TrustEVM/issues/307