### PR TITLE
Use lower_bound instead of find to locate changeset

### DIFF
--- a/node/silkworm/stagedsync/stage_history_index.cpp
+++ b/node/silkworm/stagedsync/stage_history_index.cpp
@@ -345,8 +345,8 @@ void HistoryIndex::collect_bitmaps_from_changeset(db::RWTxn& txn, const db::MapC
 
     auto start_key{db::block_key(from + 1)};
     db::Cursor source(txn, source_config);
-    auto source_data{storage ? source.lower_bound(db::to_slice(start_key), false)
-                             : source.find(db::to_slice(start_key), false)};
+    auto source_data{source.lower_bound(db::to_slice(start_key), false)};
+
     while (source_data) {
         auto source_data_key_view{db::from_slice(source_data.key)};
         reached_block_number = endian::load_big_u64(source_data_key_view.data());
@@ -416,8 +416,7 @@ std::map<Bytes, bool> HistoryIndex::collect_unique_keys_from_changeset(
 
     auto start_key{db::block_key(expected_block_number)};
     db::Cursor source(txn, source_config);
-    auto source_data{storage ? source.lower_bound(db::to_slice(start_key), false)
-                             : source.find(db::to_slice(start_key), false)};
+    auto source_data{source.lower_bound(db::to_slice(start_key), false)};
 
     while (source_data) {
         auto source_data_key_view{db::from_slice(source_data.key)};


### PR DESCRIPTION
Find will cause issue if we have empty blocks, which is indeed the case.

Silkworm part of the fix for https://github.com/eosnetworkfoundation/eos-evm/issues/551