### PR TITLE
Generate trace for calls to pre_compile addresses properly.

### DIFF
--- a/silkworm/core/execution/evm.cpp
+++ b/silkworm/core/execution/evm.cpp
@@ -245,7 +245,10 @@ evmc::Result EVM::call(const evmc_message& message) noexcept {
         }
         // Explicitly notify registered tracers (if any)
         for (auto tracer : tracers_) {
+            const ByteView code{}; // precompile code is empty.
+            tracer.get().on_execution_start(rev, message, code);
             tracer.get().on_precompiled_run(res.raw(), message.gas, state_);
+            tracer.get().on_execution_end(res.raw(),state_);
         }
     } else {
         const ByteView code{state_.get_code(message.code_address)};


### PR DESCRIPTION
Silkworm part for the solution of https://github.com/eosnetworkfoundation/eos-evm-node/issues/48

Be careful not to include this if we do not want to include this fix in the hotfix for https://github.com/eosnetworkfoundation/eos-evm-node/issues/51