### PR TITLE
Add support for input BlockNumOrHash using json object in params of eth_call and some other calls

### DIFF
--- a/silkworm/silkrpc/json/types.hpp
+++ b/silkworm/silkrpc/json/types.hpp
@@ -152,8 +152,29 @@ struct adl_serializer<silkworm::rpc::BlockNumberOrHash> {
             return silkworm::rpc::BlockNumberOrHash{json.get<std::string>()};
         } else if (json.is_number()) {
             return silkworm::rpc::BlockNumberOrHash{json.get<std::uint64_t>()};
+        } else if (json.is_object()) {
+            if (json.contains("blockHash")) {
+                const auto& hashString = json["blockHash"];
+                if (hashString.is_string()) {
+                    const auto& s = hashString.get<std::string>();
+                    if (s.length() == 66) {
+                        return silkworm::rpc::BlockNumberOrHash{s};
+                    }
+                }
+            } else if (json.contains("blockNumber")) {
+                const auto& num = json["blockNumber"];
+                if (num.is_number()) {
+                    return silkworm::rpc::BlockNumberOrHash{num.get<std::uint64_t>()};
+                }
+                else if (num.is_string()) {
+                    const auto& s = num.get<std::string>();
+                    if (s.length() <= 18) {
+                        return silkworm::rpc::BlockNumberOrHash{s};
+                    }
+                }
+            }
         }
-        return silkworm::rpc::BlockNumberOrHash{0};
+        throw std::system_error{std::make_error_code(std::errc::invalid_argument), "BlockNumberOrHash: invalid argument"};
     }
 };
 

--- a/silkworm/silkrpc/json/types.hpp
+++ b/silkworm/silkrpc/json/types.hpp
@@ -161,6 +161,7 @@ struct adl_serializer<silkworm::rpc::BlockNumberOrHash> {
                         return silkworm::rpc::BlockNumberOrHash{s};
                     }
                 }
+                throw std::system_error{std::make_error_code(std::errc::invalid_argument), "BlockNumberOrHash: blockHash"};
             } else if (json.contains("blockNumber")) {
                 const auto& num = json["blockNumber"];
                 if (num.is_number()) {
@@ -172,9 +173,10 @@ struct adl_serializer<silkworm::rpc::BlockNumberOrHash> {
                         return silkworm::rpc::BlockNumberOrHash{s};
                     }
                 }
+                throw std::system_error{std::make_error_code(std::errc::invalid_argument), "BlockNumberOrHash: blockNumber"};
             }
         }
-        throw std::system_error{std::make_error_code(std::errc::invalid_argument), "BlockNumberOrHash: invalid argument"};
+        throw std::system_error{std::make_error_code(std::errc::invalid_argument), "BlockNumberOrHash: unsupported input type"};
     }
 };
 

--- a/silkworm/silkrpc/json/types_test.cpp
+++ b/silkworm/silkrpc/json/types_test.cpp
@@ -659,6 +659,90 @@ TEST_CASE("deserialize block_number_or_hash", "[silkworm::json][from_json]") {
         CHECK(bnoh.is_tag() == false);
         CHECK(bnoh.number() == 0x374f3);
     }
+
+    SECTION("as invaild hash") {
+        nlohmann::json inputs[] = {
+            R"("0x374f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126c1")"_json,
+            R"("0x374f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126")"_json,
+            R"("zzzz")"_json,
+        };
+
+        for (const auto& json : inputs) {
+            bool exception = false;
+            try{
+            auto bnoh = json.get<BlockNumberOrHash>();
+            }
+            catch (std::exception& e) {
+                CHECK(std::string(e.what()) == "stoul");
+                exception = true;
+            }
+            CHECK(exception);
+        }
+    }
+
+    SECTION("as invaild type") {
+        auto json = R"([1,1])"_json;
+        bool exception = false;
+        try{
+        auto bnoh = json.get<BlockNumberOrHash>();
+        }
+        catch (std::exception& e) {
+            CHECK(std::string(e.what()) == "BlockNumberOrHash: unsupported input type: Invalid argument");
+            exception = true;
+        }
+        CHECK(exception);
+    }
+
+    SECTION("as invaild object with no blockHash or blockNum") {
+        auto json = R"({"aaa":"bbb"})"_json;
+        bool exception = false;
+        try{
+        auto bnoh = json.get<BlockNumberOrHash>();
+        }
+        catch (std::exception& e) {
+            CHECK(std::string(e.what()) == "BlockNumberOrHash: unsupported input type: Invalid argument");
+            exception = true;
+        }
+        CHECK(exception);
+    }
+
+    SECTION("as object with invliad blockHash") {
+        nlohmann::json inputs[] = {
+            R"({"blockHash":"0x374f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126c1"})"_json,
+            R"({"blockHash":"0x374f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126"})"_json,
+        };
+
+        for (const auto& json : inputs) {
+            bool exception = false;
+            try{
+            auto bnoh = json.get<BlockNumberOrHash>();
+            }
+            catch (std::exception& e) {
+                CHECK(std::string(e.what()) == "BlockNumberOrHash: blockHash: Invalid argument");
+                exception = true;
+            }
+            CHECK(exception);
+        }
+    }
+
+    SECTION("as object with invliad blockNumber") {
+        nlohmann::json inputs[] = {
+            R"({"blockNumber":{"aaa":"bbb"}})"_json,
+            R"({"blockNumber":"0xaaaaaaaaaaaaaaaaaaaaa"})"_json,
+        };
+
+        for (const auto& json : inputs) {
+            bool exception = false;
+            try{
+            auto bnoh = json.get<BlockNumberOrHash>();
+            }
+            catch (std::exception& e) {
+                CHECK(std::string(e.what()) == "BlockNumberOrHash: blockNumber: Invalid argument");
+                exception = true;
+            }
+            CHECK(exception);
+        }
+    }
 }
 
 TEST_CASE("serialize zero forks", "[silkworm::json][to_json]") {

--- a/silkworm/silkrpc/json/types_test.cpp
+++ b/silkworm/silkrpc/json/types_test.cpp
@@ -629,6 +629,36 @@ TEST_CASE("deserialize block_number_or_hash", "[silkworm::json][from_json]") {
         CHECK(bnoh.is_tag() == false);
         CHECK(bnoh.number() == 123456);
     }
+
+    SECTION("as objct with blockHash") {
+        auto json = R"({"blockHash":"0x374f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126c"})"_json;
+        auto bnoh = json.get<BlockNumberOrHash>();
+
+        CHECK(bnoh.is_hash() == true);
+        CHECK(bnoh.is_number() == false);
+        CHECK(bnoh.is_tag() == false);
+        CHECK(bnoh.hash() == 0x374f3a049e006f36f6cf91b02a3b0ee16c858af2f75858733eb0e927b5b7126c_bytes32);
+    }
+
+    SECTION("as objct with decimal blockNumber") {
+        auto json = R"({"blockNumber":"1966"})"_json;
+        auto bnoh = json.get<BlockNumberOrHash>();
+
+        CHECK(bnoh.is_hash() == false);
+        CHECK(bnoh.is_number() == true);
+        CHECK(bnoh.is_tag() == false);
+        CHECK(bnoh.number() == 1966);
+    }
+
+    SECTION("as objct with hex blockNumber") {
+        auto json = R"({"blockNumber":"0x374f3"})"_json;
+        auto bnoh = json.get<BlockNumberOrHash>();
+
+        CHECK(bnoh.is_hash() == false);
+        CHECK(bnoh.is_number() == true);
+        CHECK(bnoh.is_tag() == false);
+        CHECK(bnoh.number() == 0x374f3);
+    }
 }
 
 TEST_CASE("serialize zero forks", "[silkworm::json][to_json]") {


### PR DESCRIPTION
Fix for
https://github.com/eosnetworkfoundation/eos-evm-node/issues/123

Note that though the fix is using the format specified in EIP1898, the "requireCanonical" field will be ignored for now as it's much more complicated to support. 

We shall use separate issue to track that if necessary.