### PR TITLE
ensure blocks returned has passed finished state

### DIFF
--- a/silkworm/silkrpc/commands/eth_api.cpp
+++ b/silkworm/silkrpc/commands/eth_api.cpp
@@ -240,15 +240,9 @@ awaitable<void> EthereumRpcApi::handle_eth_get_block_by_hash(const nlohmann::jso
 
         const auto block_with_hash = co_await core::read_block_by_hash(*block_cache_, tx_database, block_hash);
         const auto block_number = block_with_hash->block.header.number;
-
-        const auto current_block_height = co_await core::get_current_block_number(tx_database); // block number in finished state
-        if (block_number > current_block_height) {
-            reply = make_json_content(request["id"], {});
-        } else {
-            const auto total_difficulty = co_await core::rawdb::read_total_difficulty(tx_database, block_hash, block_number);
-            const Block extended_block{*block_with_hash, total_difficulty, full_tx};
-            reply = make_json_content(request["id"], extended_block);
-        }
+        const auto total_difficulty = co_await core::rawdb::read_total_difficulty(tx_database, block_hash, block_number);
+        const Block extended_block{*block_with_hash, total_difficulty, full_tx};
+        reply = make_json_content(request["id"], extended_block);
     } catch (const std::invalid_argument& iv) {
         SILK_WARN << "invalid_argument: " << iv.what() << " processing request: " << request.dump();
         reply = make_json_content(request["id"], {});

--- a/silkworm/silkrpc/commands/eth_api.cpp
+++ b/silkworm/silkrpc/commands/eth_api.cpp
@@ -101,7 +101,9 @@ awaitable<void> EthereumRpcApi::handle_eth_block_number(const nlohmann::json& re
 
     try {
         ethdb::TransactionDatabase tx_database{*tx};
-        const auto block_height = co_await core::get_latest_block_number(tx_database);
+        // use current block number (block in finished state) instead of latest block number (in executed state)
+        // to ensure logs are available for the same block
+        const auto block_height = co_await core::get_current_block_number(tx_database);
         reply = make_json_content(request["id"], to_quantity(block_height));
     } catch (const std::exception& e) {
         SILK_ERROR << "exception: " << e.what() << " processing request: " << request.dump();
@@ -280,9 +282,12 @@ awaitable<void> EthereumRpcApi::handle_eth_get_block_by_number(const nlohmann::j
     try {
         ethdb::TransactionDatabase tx_database{*tx};
 
-        const auto block_number = co_await core::get_block_number(block_id, tx_database);
+        auto block_number = co_await core::get_block_number(block_id, tx_database);
 
         const auto current_block_height = co_await core::get_current_block_number(tx_database); // block number in finished state
+        if (block_id == core::kLatestBlockId) { // return the "latest" blocknum to "finished" blocknum
+            block_number = current_block_height;
+        }
         if (block_number > current_block_height) {
             reply = make_json_content(request["id"], nlohmann::detail::value_t::null);
         } else {
@@ -1701,13 +1706,22 @@ awaitable<void> EthereumRpcApi::handle_eth_get_logs(const nlohmann::json& reques
     try {
         ethdb::TransactionDatabase tx_database{*tx};
 
-        const auto [start, end] = co_await get_block_numbers(filter, tx_database);
+        auto [start, end] = co_await get_block_numbers(filter, tx_database);
         if (start == end && start == std::numeric_limits<std::uint64_t>::max()) {
             auto error_msg = "invalid eth_getLogs filter block_hash: " + filter.block_hash.value();
             SILK_ERROR << error_msg;
             reply = make_json_error(request["id"], 100, error_msg);
             co_await tx->close();  // RAII not (yet) available with coroutines
             co_return;
+        }
+
+        // override the "latest" blocknum to "finished" blocknum instead of "executed" blocknum
+        const auto current_block_height = co_await core::get_current_block_number(tx_database); // block number in finished state
+        if (filter.from_block.has_value() && filter.from_block.value() == core::kLatestBlockId) {
+            start = current_block_height;
+        }
+        if (filter.to_block.has_value() && filter.to_block.value() == core::kLatestBlockId) {
+            end = current_block_height;
         }
 
         std::vector<Log> logs;

--- a/silkworm/silkrpc/core/blocks.cpp
+++ b/silkworm/silkrpc/core/blocks.cpp
@@ -103,7 +103,7 @@ boost::asio::awaitable<uint64_t> get_highest_block_number(const rawdb::DatabaseR
 }
 
 boost::asio::awaitable<uint64_t> get_latest_executed_block_number(const rawdb::DatabaseReader& reader) {
-    co_return co_await stages::get_sync_stage_progress(reader, stages::kFinish); // kFinish instead of kExecution
+    co_return co_await stages::get_sync_stage_progress(reader, stages::kExecution);
 }
 
 boost::asio::awaitable<uint64_t> get_latest_block_number(const rawdb::DatabaseReader& reader) {

--- a/silkworm/silkrpc/core/blocks.cpp
+++ b/silkworm/silkrpc/core/blocks.cpp
@@ -103,7 +103,7 @@ boost::asio::awaitable<uint64_t> get_highest_block_number(const rawdb::DatabaseR
 }
 
 boost::asio::awaitable<uint64_t> get_latest_executed_block_number(const rawdb::DatabaseReader& reader) {
-    co_return co_await stages::get_sync_stage_progress(reader, stages::kExecution);
+    co_return co_await stages::get_sync_stage_progress(reader, stages::kFinish); // kFinish instead of kExecution
 }
 
 boost::asio::awaitable<uint64_t> get_latest_block_number(const rawdb::DatabaseReader& reader) {


### PR DESCRIPTION
issue https://github.com/eosnetworkfoundation/eos-evm-node/issues/70

- ensure block returned in "getblockbynumber" has passed the "kFinish" state (otherwise it returns empty object which indicates blocks not exist), so that logs will always be available for the same block.

- eth_blockNumber returns the max block number in the kFinish state instead of kExecution state.
