### PR TITLE
Revert improper merge.

### DIFF
--- a/silkworm/silkrpc/commands/rpc_api_table.cpp
+++ b/silkworm/silkrpc/commands/rpc_api_table.cpp
@@ -114,7 +114,7 @@ void RpcApiTable::add_eth_handlers() {
     method_handlers_[http::method::k_eth_chainId] = &commands::RpcApi::handle_eth_chain_id;
     method_handlers_[http::method::k_eth_protocolVersion] = &commands::RpcApi::handle_eth_protocol_version;
     method_handlers_[http::method::k_eth_syncing] = &commands::RpcApi::handle_eth_syncing;
-    method_handlers_[http::method::k_eth_gasPrice] = &commands::RpcApi::handle_eth_gas_price;
+    //method_handlers_[http::method::k_eth_gasPrice] = &commands::RpcApi::handle_eth_gas_price;
     method_handlers_[http::method::k_eth_getBlockByHash] = &commands::RpcApi::handle_eth_get_block_by_hash;
     method_handlers_[http::method::k_eth_getBlockByNumber] = &commands::RpcApi::handle_eth_get_block_by_number;
     method_handlers_[http::method::k_eth_getBlockTransactionCountByHash] = &commands::RpcApi::handle_eth_get_block_transaction_count_by_hash;


### PR DESCRIPTION
Revert "Merge pull request #230 from eosnetworkfoundation/yarkin/expose_eth_gasPrice"

This reverts commit 7bf393c3314b1fd5280abbc31d12b499a55ec199, reversing changes made to c87ecea60b3fd48c32bc2bcaedd4aba70fc3db62.

The fix needs to be merged into 1.0 first